### PR TITLE
- added a `exit` at the end of push-remote funcion

### DIFF
--- a/tmgit.sh
+++ b/tmgit.sh
@@ -31,6 +31,7 @@ function main () {
 	            echo -e "\nProblem pushing to remote repo ${TMGIT_WORK_DIR}"
 	            exit 1
 	        fi
+        exit
 	    fi
 
         # Check if 'version-all' parameter was passed


### PR DESCRIPTION
Option 2 was wisely chosen